### PR TITLE
chore: validate service account secret input

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,32 @@
+# Agent Instructions
+
+## Repository-wide Setup
+Before running tests or development scripts, configure credentials and tooling with the helper script:
+
+1. Provide Google Cloud credentials. The Go unit tests instantiate a real `GCPService`, so `GOOGLE_APPLICATION_CREDENTIALS` must point at a usable service-account JSON on disk. Either export the JSON contents directly:
+   ```bash
+   export GCP_SA_KEY="$(cat /path/to/service-account.json)"
+   ```
+   or run the script with an existing file: `scripts/setup-dev-env.sh --service-account /path/to/service-account.json`.
+   Secrets that are stored as base64 (common in CI environments) can also be assigned to `GCP_SA_KEY`; the setup script automatically decodes and validates the credentials before writing the JSON file.
+2. Supply a project identifier by either exporting `GCP_PROJECT_ID`/`TEST_PROJECT_ID` or passing `--project <your-gcp-project-id>`.
+3. Run the setup script:
+   ```bash
+   scripts/setup-dev-env.sh --project <your-gcp-project-id>
+   ```
+
+The script materializes the key at `.secrets/service-account.json`, keeps `.env` in sync (including `GOOGLE_APPLICATION_CREDENTIALS`), prepares `activate-dev.sh`, and ensures Go/Python tooling is available. Use `--force` if you need to overwrite existing credentials.
+
+### After running the script
+1. Load the generated environment and PATH adjustments:
+   ```bash
+   source activate-dev.sh
+   ```
+2. Confirm that `GOOGLE_APPLICATION_CREDENTIALS` points to the service-account file (for example `echo $GOOGLE_APPLICATION_CREDENTIALS`). If it is unset or the file is missing, `go test` will fail with errors such as `failed to create resource manager client`.
+3. Run the project tests. Typical sequences are:
+   ```bash
+   make test          # run unit tests (requires credentials)
+   make test-all      # run unit + integration suites
+   ```
+
+Integration tests default to mocked services; exporting `TEST_MODE=integration` and a real `TEST_PROJECT_ID` switches them to real GCP APIs.

--- a/scripts/setup-dev-env.sh
+++ b/scripts/setup-dev-env.sh
@@ -282,9 +282,7 @@ except ValueError as exc:
     sys.exit(1)
 
 with open(dest, "w", encoding="utf-8") as fh:
-    fh.write(payload)
-    if not payload.endswith("\n"):
-        fh.write("\n")
+    fh.write(payload.rstrip('\n') + '\n')
 PY
     then
         umask "$old_umask"

--- a/scripts/setup-dev-env.sh
+++ b/scripts/setup-dev-env.sh
@@ -244,7 +244,7 @@ write_service_account_file() {
     old_umask=$(umask)
     umask 077
 
-    if ! SA_KEY_CONTENT="$contents" python3 - "$dest" <<'PY'
+    if SA_KEY_CONTENT="$contents" python3 - "$dest" <<'PY'
 import base64
 import binascii
 import json

--- a/scripts/setup-dev-env.sh
+++ b/scripts/setup-dev-env.sh
@@ -285,14 +285,13 @@ with open(dest, "w", encoding="utf-8") as fh:
     fh.write(payload + '\n')
 PY
     then
+        chmod 600 "$dest"
+        success "Service account key materialized at $dest"
+    else
         umask "$old_umask"
         error "Failed to materialize service account credentials from GCP_SA_KEY (expected JSON or base64-encoded JSON)."
     fi
-
     umask "$old_umask"
-
-    chmod 600 "$dest"
-    success "Service account key materialized at $dest"
 }
 
 ensure_env_file

--- a/scripts/setup-dev-env.sh
+++ b/scripts/setup-dev-env.sh
@@ -258,7 +258,7 @@ def to_json_payload(value: str) -> str:
     candidate = value.strip()
     try:
         json.loads(candidate)
-        return value
+        return candidate
     except json.JSONDecodeError:
         cleaned = "".join(value.split())
         try:

--- a/scripts/setup-dev-env.sh
+++ b/scripts/setup-dev-env.sh
@@ -260,7 +260,7 @@ def to_json_payload(value: str) -> str:
         json.loads(candidate)
         return candidate
     except json.JSONDecodeError:
-        whitespace_removed = "".join(value.split())
+        whitespace_removed = value.replace(' ', '').replace('\t', '').replace('\n', '').replace('\r', '')
         try:
             decoded = base64.b64decode(whitespace_removed, validate=True)
         except binascii.Error as exc:

--- a/scripts/setup-dev-env.sh
+++ b/scripts/setup-dev-env.sh
@@ -288,7 +288,6 @@ PY
         chmod 600 "$dest"
         success "Service account key materialized at $dest"
     else
-        umask "$old_umask"
         error "Failed to materialize service account credentials from GCP_SA_KEY (expected JSON or base64-encoded JSON)."
     fi
     umask "$old_umask"

--- a/scripts/setup-dev-env.sh
+++ b/scripts/setup-dev-env.sh
@@ -282,7 +282,7 @@ except ValueError as exc:
     sys.exit(1)
 
 with open(dest, "w", encoding="utf-8") as fh:
-    fh.write(payload.rstrip('\n') + '\n')
+    fh.write(payload + '\n')
 PY
     then
         umask "$old_umask"

--- a/scripts/setup-dev-env.sh
+++ b/scripts/setup-dev-env.sh
@@ -275,7 +275,6 @@ def to_json_payload(value: str) -> str:
             raise ValueError("decoded key is not valid JSON") from exc
         return decoded_text
 
-
 try:
     payload = to_json_payload(raw)
 except ValueError as exc:

--- a/scripts/setup-dev-env.sh
+++ b/scripts/setup-dev-env.sh
@@ -233,6 +233,71 @@ update_env_var() {
     mv "$tmp" "$ENV_FILE"
 }
 
+write_service_account_file() {
+    local dest="$1"
+    local contents="$2"
+
+    info "Writing service account credentials to $dest"
+    mkdir -p "$(dirname "$dest")"
+
+    local old_umask
+    old_umask=$(umask)
+    umask 077
+
+    if ! SA_KEY_CONTENT="$contents" python3 - "$dest" <<'PY'
+import base64
+import binascii
+import json
+import os
+import sys
+
+dest = sys.argv[1]
+raw = os.environ.get("SA_KEY_CONTENT", "")
+
+def to_json_payload(value: str) -> str:
+    candidate = value.strip()
+    try:
+        json.loads(candidate)
+        return value
+    except json.JSONDecodeError:
+        cleaned = "".join(value.split())
+        try:
+            decoded = base64.b64decode(cleaned, validate=True)
+        except binascii.Error as exc:
+            raise ValueError("service account key is neither valid JSON nor base64") from exc
+        try:
+            decoded_text = decoded.decode("utf-8")
+        except UnicodeDecodeError as exc:
+            raise ValueError("decoded key could not be interpreted as UTF-8 text") from exc
+        try:
+            json.loads(decoded_text)
+        except json.JSONDecodeError as exc:
+            raise ValueError("decoded key is not valid JSON") from exc
+        return decoded_text
+
+
+try:
+    payload = to_json_payload(raw)
+except ValueError as exc:
+    print(f"Unable to parse GCP_SA_KEY: {exc}", file=sys.stderr)
+    sys.exit(1)
+
+with open(dest, "w", encoding="utf-8") as fh:
+    fh.write(payload)
+    if not payload.endswith("\n"):
+        fh.write("\n")
+PY
+    then
+        umask "$old_umask"
+        error "Failed to materialize service account credentials from GCP_SA_KEY (expected JSON or base64-encoded JSON)."
+    fi
+
+    umask "$old_umask"
+
+    chmod 600 "$dest"
+    success "Service account key materialized at $dest"
+}
+
 ensure_env_file
 
 PROJECT_ID="$PROJECT_OVERRIDE"
@@ -255,14 +320,7 @@ if [[ -n "${GCP_SA_KEY:-}" ]]; then
     if [[ -f "$SERVICE_ACCOUNT_DEST" && "$FORCE" -eq 0 ]]; then
         info "Service account file already exists at $SERVICE_ACCOUNT_DEST (use --force to overwrite)"
     else
-        info "Writing service account credentials to $SERVICE_ACCOUNT_DEST"
-        mkdir -p "$(dirname "$SERVICE_ACCOUNT_DEST")"
-        old_umask=$(umask)
-        umask 077
-        printf '%s' "$GCP_SA_KEY" > "$SERVICE_ACCOUNT_DEST"
-        umask "$old_umask"
-        chmod 600 "$SERVICE_ACCOUNT_DEST"
-        success "Service account key materialized"
+        write_service_account_file "$SERVICE_ACCOUNT_DEST" "$GCP_SA_KEY"
     fi
     CREDENTIALS_PATH="$SERVICE_ACCOUNT_DEST"
 elif [[ -n "${GOOGLE_APPLICATION_CREDENTIALS:-}" ]]; then

--- a/scripts/setup-dev-env.sh
+++ b/scripts/setup-dev-env.sh
@@ -260,9 +260,9 @@ def to_json_payload(value: str) -> str:
         json.loads(candidate)
         return candidate
     except json.JSONDecodeError:
-        cleaned = "".join(candidate.split())
+        whitespace_removed = "".join(value.split())
         try:
-            decoded = base64.b64decode(cleaned, validate=True)
+            decoded = base64.b64decode(whitespace_removed, validate=True)
         except binascii.Error as exc:
             raise ValueError("service account key is neither valid JSON nor base64") from exc
         try:

--- a/scripts/setup-dev-env.sh
+++ b/scripts/setup-dev-env.sh
@@ -260,7 +260,7 @@ def to_json_payload(value: str) -> str:
         json.loads(candidate)
         return candidate
     except json.JSONDecodeError:
-        cleaned = "".join(value.split())
+        cleaned = "".join(candidate.split())
         try:
             decoded = base64.b64decode(cleaned, validate=True)
         except binascii.Error as exc:


### PR DESCRIPTION
## Summary
- validate and decode `GCP_SA_KEY` when provisioning credentials so the setup script accepts raw JSON or base64-encoded secrets
- document that base64 secrets are supported in the repository-wide agent instructions

## Testing
- GCP_SA_KEY=eyJ0eXBlIjoic2VydmljZV9hY2NvdW50IiwicHJvamVjdF9pZCI6ImRlbW8ifQ== scripts/setup-dev-env.sh --skip-python --skip-go-tools --service-account /tmp/test-sa.json --project demo


------
https://chatgpt.com/codex/tasks/task_e_68ca132102b4832f96ab1850bd08c057